### PR TITLE
fix: 북마크 저장 시 pbAuth 덮어쓰기 수정

### DIFF
--- a/src/api/updateData.js
+++ b/src/api/updateData.js
@@ -1,8 +1,11 @@
 import pb from './pocketbase';
 
 export default async function updateUserData(collectionName, id, data) {
-  sessionStorage.setItem('pb_auth', JSON.stringify({ model: 'model', token: data }));
-  localStorage.setItem('pb_auth', JSON.stringify({ model: 'model', token: data }));
+  if (collectionName !== 'bookmarkItem') {
+    sessionStorage.setItem('pb_auth', JSON.stringify({ model: 'model', token: data }));
+    localStorage.setItem('pb_auth', JSON.stringify({ model: 'model', token: data }));
+  }
+
   const record = await pb.collection(collectionName).update(id, data);
   return record;
 }


### PR DESCRIPTION
# PR 서식

- PR 이름 : 북마크 저장 시 pbAuth 훼손 수정

- 수정한 이슈: #137 

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [x] develop 브랜치에서 최신 데이터를 가져오기 위한 PR

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

### PR 상세(활동 및 수정사항)

- 어떤 변경점이 있었는지 상술해주세요.
- 북마크 저장 시 pbAuth 훼손 방지를 위해 updateUserData 함수 재구성
